### PR TITLE
Use TCP level for TCP_NODELAY option.

### DIFF
--- a/src/mysql/socket.d
+++ b/src/mysql/socket.d
@@ -15,7 +15,7 @@ struct Socket
         socket_ = new TcpSocket();
         socket_.connect(new InternetAddress(host, port));
         socket_.setOption(SocketOptionLevel.SOCKET, SocketOption.KEEPALIVE, true);
-        socket_.setOption(SocketOptionLevel.SOCKET, SocketOption.TCP_NODELAY, true);
+        socket_.setOption(SocketOptionLevel.TCP, SocketOption.TCP_NODELAY, true);
         socket_.setOption(SocketOptionLevel.SOCKET, SocketOption.SNDTIMEO, 30.seconds);
         socket_.setOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, 30.seconds);
     }


### PR DESCRIPTION
TCP_NODELAY is a TCP level as described here: https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-setsockopt
Using SOCKET level results in Permission denied in linux.